### PR TITLE
Use new oauth api of backend

### DIFF
--- a/config.json.default
+++ b/config.json.default
@@ -1,4 +1,4 @@
 {
-  "api_url": "http://localhost:8000/api/v0",
+  "api_url": "https://paperhub.io/dev/backend/branches/oauth",
   "api_version": "0.0.0"
 }

--- a/config.json.default
+++ b/config.json.default
@@ -1,4 +1,4 @@
 {
-  "api_url": "https://paperhub.io/dev/backend/branches/oauth",
+  "api_url": "https://paperhub.io/dev/backend/branches/master",
   "api_version": "0.0.0"
 }

--- a/src/js/controllers/oauthOrcid.js
+++ b/src/js/controllers/oauthOrcid.js
@@ -3,7 +3,7 @@ module.exports = function (app) {
     '$scope', '$routeParams', '$location', 'authService',
     function ($scope, $routeParams, $location, authService) {
       authService
-        .signinOrcid($routeParams.code, $routeParams.state)
+        .signinToken($routeParams.token)
         .then(
           function success(data) {
             $location.path('/welcome').search({});

--- a/src/js/services/auth.js
+++ b/src/js/services/auth.js
@@ -3,12 +3,12 @@ module.exports = function (app) {
     function (config, $http, $q, $window) {
       var authService = {
         inProgress: false,
-        orcidUrl: config.api_url + '/oauth/orcid',
-        user: {
-          displayName: "Karl Schmidt",
-          gravatarMd5: "abc",
-          userName: "karli"
-        }
+        orcidUrl: config.api_url + '/oauth/orcid?app_callback=' +
+          encodeURIComponent(
+            $window.location.origin +
+            $window.location.pathname +
+            '#/oauth/orcid'
+          )
       };
 
       function signin(url, data, config) {
@@ -57,9 +57,9 @@ module.exports = function (app) {
       // grab token from session or local storage
       var token = $window.sessionStorage.token || $window.localStorage.token;
 
-      // sign in if token is present
-      if (token) {
-        signin(
+      // sign in with a token
+      authService.signinToken = function (token) {
+        return signin(
           config.api_url + '/signin',
           null,
           {
@@ -67,6 +67,11 @@ module.exports = function (app) {
             timeout: 10000
           }
         );
+      };
+
+      // sign in if token is present
+      if (token) {
+        authService.signinToken(token);
       }
 
       // sign in function for ORCID viaOAuth

--- a/src/templates/shared/navbar_user.html
+++ b/src/templates/shared/navbar_user.html
@@ -12,8 +12,8 @@
       <span class="ph-padding-left ph-padding-right">Signing in...</span>
     </progressbar>
   </li>
-  <li ng-show="auth.user" class="dropdown" is-open="dropdown_open">
-    <a href class="dropdown-toggle">
+  <li ng-show="auth.user" class="dropdown" is-open="dropdown_open" dropdown>
+    <a href="" class="dropdown-toggle" dropdown-toggle>
       <img src="https://secure.gravatar.com/avatar/{{auth.user.gravatarMd5}}?s=30"
         class="ph-avatar" alt="{{auth.user.displayName}} avatar">
       {{auth.user.displayName}}


### PR DESCRIPTION
The backend now directly redirects to the frontend with the paperhub x-auth-token. This saves another round-trip of api calls and integrates nicely in the authService.