### PR TITLE
[pdfjs] use pdf.js web worker

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -117,7 +117,11 @@ gulp.task('static', function () {
   var mathjax = gulp.src(mathjax_src, {base: mathjax_base})
     .pipe(gulp.dest('build/assets/mathjax'));
 
-  return merge(html, images, bootstrap, fontawesome, mathjax);
+  var pdfjs = gulp.src('bower_components/pdfjs-dist/build/pdf.worker.js')
+    .pipe(debug ? gutil.noop() : streamify(uglify()))
+    .pipe(gulp.dest('build/assets/pdfjs'));
+
+  return merge(html, images, bootstrap, fontawesome, mathjax, pdfjs);
 });
 
 // compile less to css

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "angular-route-segment": "./bower_components/angular-route-segment/build/angular-route-segment.js",
     "angular-sanitize": "./bower_components/angular-sanitize/angular-sanitize.js",
     "highlightjs": "./bower_components/highlightjs/highlight.pack.js",
-    "pdfjs": "./bower_components/pdfjs-dist/build/pdf.combined.js",
+    "pdfjs": "./bower_components/pdfjs-dist/build/pdf.js",
     "mentio": "./bower_components/ment.io/dist/mentio.js",
     "jquery": "./bower_components/jquery/dist/jquery.js",
     "kramed": "./bower_components/kramed/lib/kramed.js"

--- a/src/js/config/index.js
+++ b/src/js/config/index.js
@@ -1,4 +1,5 @@
 module.exports = function (app) {
   require('./mathjax.js')(app);
+  require('./pdf.js')(app);
   require('./routes.js')(app);
 };

--- a/src/js/config/pdf.js
+++ b/src/js/config/pdf.js
@@ -1,0 +1,3 @@
+module.exports = function (app) {
+  PDFJS.workerSrc = 'assets/pdfjs/pdf.worker.js';
+};


### PR DESCRIPTION
The js file must be loaded dynamically for a web worker. Therefore, we minify the pdf.worker.js file (if not in debug mode) and place it in the assets dir. Browserify then only needs to require the standard pdf.js file instead of pdf.combined.js.

This also reduces the initial loading time on pages without a pdf view since the 1.2MB js file is loaded only when a pdf is actually displayed.