### PR TITLE
[less] fix header button style in mobile view

### DIFF
--- a/src/less/paperhub/header.less
+++ b/src/less/paperhub/header.less
@@ -49,23 +49,23 @@
       padding-top: 7px;
       padding-bottom: 7px;
     }
-  }
-  @media (max-width: @screen-xs-max){
-    .navbar-collapse {
-      border: none;
-    }
+    @media (max-width: @screen-xs-max){
+      .navbar-collapse {
+        border: none;
+      }
 
-    .navbar-collapse, .btn-default {
-      width: 100%;
-      min-width: 100% !important;
-    }
+      .navbar-collapse, .btn-default {
+        width: 100%;
+        min-width: 100% !important;
+      }
 
-    .btn-default {
-      border-left: none;
-      border-right: none;
-      border-color: @nav-tabs-border-color;
-      border-top: @ph-border-height solid @ph-highlight-color;
-      text-align: left;
+      .btn-default {
+        border-left: none;
+        border-right: none;
+        border-color: @nav-tabs-border-color;
+        border-top: @ph-border-height solid @ph-highlight-color;
+        text-align: left;
+      }
     }
   }
 }


### PR DESCRIPTION
The subnav button styles are only applied to descendants of `.ph-header-submenu-container`. Works nicely [here](https://paperhub.io/dev/frontend/branches/profile-button/).

Fixes #43.