### PR TITLE
Add article import from approved sources

### DIFF
--- a/config.json.default
+++ b/config.json.default
@@ -1,4 +1,4 @@
 {
-  "api_url": "https://paperhub.io/dev/backend/branches/master",
+  "api_url": "https://paperhub.io/dev/backend/branches/articles",
   "api_version": "0.0.0"
 }

--- a/src/js/config/routes.js
+++ b/src/js/config/routes.js
@@ -6,7 +6,7 @@ module.exports = function (app) {
       $routeSegmentProvider
         .when('/', 'main')
         .when('/articles', 'article')
-        .when('/articles/new', 'article.new')
+        .when('/articles/new', 'articlenew')
         .when('/articles/:id', 'article')
         .when('/articles/:id/activity', 'article.activity')
         .when('/articles/:id/comments', 'article.comments')
@@ -56,9 +56,6 @@ module.exports = function (app) {
               dependencies: ['num']
             })
           .up()
-          .segment('new', {
-            templateUrl: 'templates/article/new.html'
-          })
           .segment('settings', {
             templateUrl: 'templates/article/settings.html',
             dependencies: ['id']
@@ -69,6 +66,9 @@ module.exports = function (app) {
             dependencies: ['id']
           })
         .up()
+        .segment('articlenew', {
+          templateUrl: 'templates/article/new.html'
+        })
 
         .segment('contact',{
           templateUrl: 'templates/contact/contact.html'

--- a/src/js/controllers/article.js
+++ b/src/js/controllers/article.js
@@ -89,10 +89,23 @@ var discussion = {
 
 module.exports = function (app) {
   app.controller('ArticleCtrl', [
-    '$scope', '$route', '$routeSegment', '$document', 'config',
+    '$scope', '$route', '$routeSegment', '$document', '$http', 'config',
     'authService', 'NotificationsService',
-    function($scope, $route, $routeSegment, $document, config,
+    function($scope, $route, $routeSegment, $document, $http, config,
              authService, notificationsService) {
+
+      // fetch article
+      $http.get(config.api_url + '/articles/' + $routeSegment.$routeParams.id)
+        .success(function (article) {
+          $scope.article = article;
+        })
+        .error(function (data) {
+          notificationsService.notifications.push({
+            type: 'error',
+            message: data.message ? data.message : 'could not fetch article ' +
+              '(unknown reason)'
+          });
+        });
 
       // DEBUG
       var article =
@@ -110,7 +123,6 @@ module.exports = function (app) {
       // END DEBUG
 
       $scope.auth = authService;
-      $scope.article = article;
       // Expose the routeSegment to be able to determine the active tab in the
       // template.
       $scope.$routeSegment = $routeSegment;

--- a/src/js/controllers/articleNew.js
+++ b/src/js/controllers/articleNew.js
@@ -21,10 +21,10 @@ module.exports = function (app) {
 
           // initiate http request
           canceler = $q.defer();
-          $http.get(
-            config.api_url + '/articles/external/' + encodeURIComponent(handle),
-            {timeout: canceler.promise}
-          )
+          $http.get(config.api_url + '/articles/external', {
+            params: {handle: handle},
+            timeout: canceler.promise
+          })
             .success(function (article) {
               $scope.article = article;
               $scope.metadataCollapsed = false;
@@ -37,10 +37,9 @@ module.exports = function (app) {
 
       $scope.submitApproved = function () {
         $scope.submitting = true;
-        $http.post(
-          config.api_url + '/articles/external/' +
-          encodeURIComponent($scope.handle)
-        )
+        $http.post(config.api_url + '/articles/external', undefined, {
+          params: {handle: $scope.handle},
+        })
           .success(function (article) {
             $scope.submitting = false;
             $location.path('/articles/' + article._id);

--- a/src/js/controllers/articleNew.js
+++ b/src/js/controllers/articleNew.js
@@ -1,0 +1,17 @@
+module.exports = function (app) {
+  app.controller('ArticleNewCtrl', [
+    '$scope', '$http', 'config', 'authService',
+    function($scope, $http, config, authService) {
+      $scope.$watch('handle', function (handle) {
+        $http.get(config.api_url + '/articles/external/' +
+                  encodeURIComponent(handle))
+          .success(function (metadata) {
+            $scope.metadata = metadata;
+          })
+          .error(function () {
+            $scope.metadata = undefined;
+          });
+      });
+    }
+  ]);
+};

--- a/src/js/controllers/articleNew.js
+++ b/src/js/controllers/articleNew.js
@@ -27,6 +27,7 @@ module.exports = function (app) {
           )
             .success(function (article) {
               $scope.article = article;
+              $scope.metadataCollapsed = false;
             })
             .error(function () {
               $scope.article = undefined;

--- a/src/js/controllers/articleNew.js
+++ b/src/js/controllers/articleNew.js
@@ -1,17 +1,58 @@
 module.exports = function (app) {
   app.controller('ArticleNewCtrl', [
-    '$scope', '$http', 'config', 'authService',
-    function($scope, $http, config, authService) {
+    '$scope', '$http', '$q', '$location', 'config', 'authService',
+    'NotificationsService',
+    function($scope, $http, $q, $location, config, authService,
+             NotificationService) {
+      // used to cancel running http requests
+      var canceler;
+
       $scope.$watch('handle', function (handle) {
-        $http.get(config.api_url + '/articles/external/' +
-                  encodeURIComponent(handle))
-          .success(function (metadata) {
-            $scope.metadata = metadata;
-          })
-          .error(function () {
-            $scope.metadata = undefined;
-          });
+        $scope.article = undefined;
+
+        // collapse metadata panel (nothing to view!)
+        $scope.metadataCollapsed = true;
+
+        if (handle) {
+          // cancel running http request
+          if (canceler) {
+            canceler.resolve();
+          }
+
+          // initiate http request
+          canceler = $q.defer();
+          $http.get(
+            config.api_url + '/articles/external/' + encodeURIComponent(handle),
+            {timeout: canceler.promise}
+          )
+            .success(function (article) {
+              $scope.article = article;
+            })
+            .error(function () {
+              $scope.article = undefined;
+            });
+        }
       });
+
+      $scope.submitApproved = function () {
+        $scope.submitting = true;
+        $http.post(
+          config.api_url + '/articles/external/' +
+          encodeURIComponent($scope.handle)
+        )
+          .success(function (article) {
+            $scope.submitting = false;
+            $location.path('/articles/' + article._id);
+          })
+          .error(function (data) {
+            $scope.submitting = false;
+            NotificationsService.notifications.push({
+              type: 'error',
+              message: data.message || 'could not add article (unknown reason)'
+            });
+          });
+
+      };
     }
   ]);
 };

--- a/src/js/controllers/index.js
+++ b/src/js/controllers/index.js
@@ -1,6 +1,7 @@
 module.exports = function (app) {
   require('./annotation.js')(app);
   require('./article.js')(app);
+  require('./articleNew.js')(app);
   require('./discussion.js')(app);
   require('./navbar.js')(app);
   require('./navbar_user.js')(app);

--- a/src/templates/article/header.html
+++ b/src/templates/article/header.html
@@ -7,22 +7,17 @@
   </div>
   <div class="media-body">
     <h2 class="media-heading">
-      <!-- TODO use route segment here -->
-      <a href="#/articles/{{article._id}}">
-        {{article.title}}
-      </a><br>
+      <a href="#/articles/{{article._id}}">{{article.title}}</a>
     </h2>
     <h4>
       <span ng-repeat="author in article.authors">
-        <!-- TODO use route segment here -->
-        <a href="#/users/{{author.userName}}">
-          {{author.displayName}}</a>{{$last ? '' :', '}}
+        {{author}}{{$last ? '' :', '}}
       </span>
     </h4>
     <p class="text-muted">
       <i class="fa fa-fw fa-cloud-upload"></i> uploaded by
-      <a href="#/users/{{article.owner.accountName}}">
-        {{article.owner.displayName}}
+      <a href="#/users/{{article.uploadedBy.username}}">
+        {{article.uploadedBy.displayName}}
       </a>
     </p>
   </div>

--- a/src/templates/article/header.html
+++ b/src/templates/article/header.html
@@ -15,7 +15,7 @@
       </span>
     </h4>
     <p class="text-muted">
-      <i class="fa fa-fw fa-cloud-upload"></i> uploaded by
+      <i class="fa fa-fw fa-cloud-download"></i> imported by
       <a href="#/users/{{article.uploadedBy.username}}">
         {{article.uploadedBy.displayName}}
       </a>

--- a/src/templates/article/new.html
+++ b/src/templates/article/new.html
@@ -40,7 +40,7 @@
                     Article URL
                   </label>
                   <div class="col-sm-9">
-                    <input ng-model="handle"
+                    <input ng-model="handle" ng-disabled="submitting"
                       name="handle" type="text"
                       class="form-control" id="handle"
                       placeholder="Provide article URL or identifier">
@@ -65,17 +65,6 @@
                   <div class="row">
                     <div class="col-sm-offset-3 col-sm-9">
                       <p class="text-right">
-                        <button type="submit" ng-disabled="!article"
-                            ng-click="metadataCollapsed = !metadataCollapsed"
-                            class="btn btn-default">
-                            <i class="fa fa-fw" ng-class="{
-                              'fa-caret-down': metadataCollapsed,
-                              'fa-caret-up': !metadataCollapsed
-                              }"></i>
-                          <span ng-show="metadataCollapsed">Show</span>
-                          <span ng-show="!metadataCollapsed">Hide</span>
-                          metadata
-                        </button>
                         <button type="submit" ng-disabled="!article || submitting"
                             ng-click="submitApproved()"
                             class="btn btn-primary">
@@ -111,18 +100,44 @@
                             </p>
                           </div>
                         </div>
+                        <div class="form-group">
+                          <label class="control-label col-sm-3">
+                            Published
+                          </label>
+                          <div class="col-sm-9">
+                            <p class="form-control-static">
+                              {{article.publishedAt | date:'longDate'}}
+                            </p>
+                          </div>
+                        </div>
+                        <div class="form-group" ng-if="article.tags.length">
+                          <label class="control-label col-sm-3">
+                            Tags
+                          </label>
+                          <div class="col-sm-9">
+                            <p class="form-control-static">
+                              <span ng-repeat="tag in article.tags">
+                                {{tag}}{{$last ? '' : ', '}}
+                              </span>
+                            </p>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div class="panel-footer">
-                Currently approved article sources are:
-                <ul>
-                  <li><a href="http://arxiv.org/">arXiv</a></li>
-                </ul>
-                Please <a href="#/contact">contact us</a> to suggest further article sources.
+              <div class="alert alert-info">
+                <p><strong>Note:</strong></p>
+                <p>
+                  Currently approved article sources are:
+                  <ul>
+                    <li><a href="http://arxiv.org/">arXiv</a></li>
+                  </ul>
+                  Please <a href="#/contact">contact us</a> to suggest further
+                  article sources.
+                </p>
+              </div>
             </div>
           </div>
         </div>

--- a/src/templates/article/new.html
+++ b/src/templates/article/new.html
@@ -1,14 +1,63 @@
-<!-- Page content -->
-<div class="container">
-  <div class="row">
-    <h4>View PDF</h4>
-    <form name="pdfForm" role="form" ng-submit="fetchUrl = url">
-      <div class="form-group">
-        <div class="col-xs-4">
-          <input type="url" ng-model="url" placeholder="Enter PDF URL"
-              class="form-control"/>
+<div ng-controller="ArticleNewCtrl">
+  <div class="ph-header ph-lg-margin-bottom">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12">
+          <!-- title -->
+          <div class="media">
+            <div class="media-left">
+              <span class="fa-stack ph-icon">
+                <i class="fa fa-circle fa-stack-2x fa-inverse"></i>
+                <i class="fa fa-file-text-o fa-stack-1x"></i>
+              </span>
+            </div>
+            <div class="media-body ph-vertical-middle">
+              <!--heading-->
+              <h2 class="media-heading">Add an article</h2>
+            </div>
+          </div>
         </div>
-        <input class="btn btn-default" type="submit" value="Fetch" />
+      </div>
+    </div>
+
+  </div>
+  <div class="container">
+    <form name="articleNewForm" role="form" ng-submit="fetchUrl = url">
+      <div class="row">
+        <div class="col-md-12">
+          <p>
+            You can add any arXiv article to PaperHub by providing an arXiv URL
+            or an arxiv id such as <em>1208.0264v4</em>. More article
+            repositories will become available in the near future!
+          </p>
+          <div class="row">
+            <div class="form-group">
+              <div class="col-xs-4">
+                <input ng-model="handle"
+                  placeholder="Enter arxiv URL or arxiv id"
+                  class="form-control"/>
+              </div>
+            </div>
+          </div>
+          <div class="row" ng-show="metadata">
+            <div class="col-xs-6">
+              <table class="table">
+                <tr>
+                  <th scope="row">Title</td>
+                  <td>{{metadata.title}}</td>
+                </tr>
+                <tr>
+                  <th scope="row">Authors</td>
+                  <td>
+                    <span ng-repeat="author in metadata.authors">
+                      {{author}}<span ng-show="!$last">,</span>
+                    </span>
+                  </td>
+                </tr>
+              </table>
+            </div>
+          </div>
+        </div>
       </div>
     </form>
   </div>

--- a/src/templates/article/new.html
+++ b/src/templates/article/new.html
@@ -22,43 +22,127 @@
 
   </div>
   <div class="container">
-    <form name="articleNewForm" role="form" ng-submit="fetchUrl = url">
+    <form name="articleNewForm" role="form">
+
+      <!-- article source -->
       <div class="row">
-        <div class="col-md-12">
-          <p>
-            You can add any arXiv article to PaperHub by providing an arXiv URL
-            or an arxiv id such as <em>1208.0264v4</em>. More article
-            repositories will become available in the near future!
-          </p>
-          <div class="row">
-            <div class="form-group">
-              <div class="col-xs-4">
-                <input ng-model="handle"
-                  placeholder="Enter arxiv URL or arxiv id"
-                  class="form-control"/>
+
+        <!-- approved source -->
+        <div class="col-sm-5">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h4 class="panel-title">Add from approved source</h4>
+            </div>
+            <div class="panel-body">
+              <div class="form-horizontal">
+                <div class="form-group has-feedback">
+                  <label for="handle" class="control-label col-sm-3">
+                    Article URL
+                  </label>
+                  <div class="col-sm-9">
+                    <input ng-model="handle"
+                      name="handle" type="text"
+                      class="form-control" id="handle"
+                      placeholder="Provide article URL or identifier">
+                  </div>
+                </div>
+                <div ng-show="article._id">
+                  <div class="row">
+                    <div class="col-sm-offset-3 col-sm-9">
+                      <p>
+                        This article has already been added to PaperHub.
+                      </p>
+                      <p class="text-right">
+                        <a href="#/articles/{{article._id}}" class="btn btn-primary">
+                          <i class="fa fa-fw fa-file-pdf-o"></i>
+                          Show article
+                        </a>
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div ng-show="!article._id">
+                  <div class="row">
+                    <div class="col-sm-offset-3 col-sm-9">
+                      <p class="text-right">
+                        <button type="submit" ng-disabled="!article"
+                            ng-click="metadataCollapsed = !metadataCollapsed"
+                            class="btn btn-default">
+                            <i class="fa fa-fw" ng-class="{
+                              'fa-caret-down': metadataCollapsed,
+                              'fa-caret-up': !metadataCollapsed
+                              }"></i>
+                          <span ng-show="metadataCollapsed">Show</span>
+                          <span ng-show="!metadataCollapsed">Hide</span>
+                          metadata
+                        </button>
+                        <button type="submit" ng-disabled="!article || submitting"
+                            ng-click="submitApproved()"
+                            class="btn btn-primary">
+                          <i class="fa fa-fw fa-plus" ng-show="!submitting"></i>
+                          <i class="fa fa-fw fa-spinner fa-spin" ng-show="submitting"></i>
+                          Add to PaperHub
+                        </button>
+                      </p>
+                    </div>
+                  </div>
+                  <div collapse="metadataCollapsed" ng-init="metadataCollapsed = true">
+                    <div class="panel panel-default">
+                      <div class="panel-body">
+                        <div class="form-group">
+                          <label class="control-label col-sm-3">
+                            Title
+                          </label>
+                          <div class="col-sm-9">
+                            <p class="form-control-static">
+                              {{article.title}}
+                            </p>
+                          </div>
+                        </div>
+                        <div class="form-group">
+                          <label class="control-label col-sm-3">
+                            Authors
+                          </label>
+                          <div class="col-sm-9">
+                            <p class="form-control-static">
+                              <span ng-repeat="author in article.authors">
+                                {{author}}{{$last ? '' : ', '}}
+                              </span>
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-          <div class="row" ng-show="metadata">
-            <div class="col-xs-6">
-              <table class="table">
-                <tr>
-                  <th scope="row">Title</td>
-                  <td>{{metadata.title}}</td>
-                </tr>
-                <tr>
-                  <th scope="row">Authors</td>
-                  <td>
-                    <span ng-repeat="author in metadata.authors">
-                      {{author}}<span ng-show="!$last">,</span>
-                    </span>
-                  </td>
-                </tr>
-              </table>
+            <div class="panel-footer">
+                Currently approved article sources are:
+                <ul>
+                  <li><a href="http://arxiv.org/">arXiv</a></li>
+                </ul>
+                Please <a href="#/contact">contact us</a> to suggest further article sources.
             </div>
           </div>
         </div>
+
+        <!-- private PDF -->
+        <div class="col-sm-offset-1 col-sm-5">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h4 class="panel-title">Upload PDF (disabled!)</h4>
+            </div>
+            <div class="panel-body">
+              <button type="button" class="btn btn-default" disabled>
+                Upload PDF
+              </button>
+            </div>
+          </div>
+        </div>
+
       </div>
     </form>
+
   </div>
 </div>

--- a/src/templates/article/text/index.html
+++ b/src/templates/article/text/index.html
@@ -7,9 +7,9 @@
     <div class="clearfix"></div>
   </div>
 </div>
-<div class="row">
+<div class="row" ng-if="article.file.url">
   <pdf
-    url="{{article.url}}"
+    url="{{article.file.url}}"
     on-mouseup="phGetSelection()"
     class="col-md-9"
     ></pdf>

--- a/src/templates/shared/navbar_user.html
+++ b/src/templates/shared/navbar_user.html
@@ -23,6 +23,11 @@
     </a>
     <ul class="dropdown-menu">
       <li ng-show="auth.user.username">
+        <a href="#/articles/new">
+          <i class="fa fa-fw fa-plus"></i> Add article
+        </a>
+      </li>
+      <li ng-show="auth.user.username">
         <a href="#/users/{{auth.user.username}}">
           <i class="fa fa-fw fa-user"></i> Profile
         </a>


### PR DESCRIPTION
* *Add article* entry in user menu (you have to set a username in order to see the entry)
* *Add from approved source* uses articles API to import articles from other sites (restricted to arxiv at the moment, but handling further sites only requires adaption of backend code)
* Redirect to article when trying to import an article that's already stored in our db
* Fetch article from API in article controller
* Adapt article template to slightly different article schema

Check out the deployed version here https://paperhub.io/dev/frontend/branches/articles-rebase/#/articles/54f3a12ece919a120b6d7e3c