### PR TITLE
load more of MathJax

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -127,7 +127,9 @@ gulp.task('static', function () {
     'config/Safe.js',
     'extensions/Safe.js',
     'fonts/HTML-CSS/TeX/woff/*.woff',
-    'jax/output/HTML-CSS/fonts/TeX/fontdata.js'
+    'jax/element/**',
+    'jax/output/HTML-CSS/autoload/**',
+    'jax/output/HTML-CSS/fonts/TeX/**'
   ], function(path) {
     return mathjax_base + path;
   });


### PR DESCRIPTION
Allows using `\iint`, `\iiint`, and a number of other special symbols, allows `\\` line breaks. Fixes bug #2.